### PR TITLE
Task uplift

### DIFF
--- a/.github/workflows/BuildAndTestOnEveryPush.yml
+++ b/.github/workflows/BuildAndTestOnEveryPush.yml
@@ -25,4 +25,4 @@ jobs:
       run: dotnet pack --configuration Release --include-source
       
     - name: Push NuGet package to the testfeed
-      run: dotnet nuget push Frends.Community.AesEncryptFile\bin\Release\Frends.Community.AesEncryptFile.*.nupkg  --api-key ${{ secrets.COMMUNITY_FEED_API_KEY }} --source https://www.myget.org/F/frends-community-test/api/v2/package --symbol-source https://www.myget.org/F/frends-community-test/symbols/api/v2/package
+      run: dotnet nuget push Frends.Community.AesEncryptFile\bin\Release\Frends.Community.AesEncryptFile.*.nupkg  --api-key ${{ secrets.COMMUNITY_FEED_API_KEY }} --source https://www.myget.org/F/frends-community-test/api/v2/package

--- a/Frends.Community.AesEncryptFile/Frends.Community.AesEncryptFile.csproj
+++ b/Frends.Community.AesEncryptFile/Frends.Community.AesEncryptFile.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-	<TargetFrameworks>netstandard2.0;net471</TargetFrameworks>
+	<TargetFrameworks>netstandard2.0;net471;net6.0;net8.0</TargetFrameworks>
     <authors>HiQ Finland</authors>
     <copyright>HiQ Finland</copyright>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
@@ -10,7 +10,7 @@
     <IncludeSource>true</IncludeSource>
     <PackageTags>Frends</PackageTags>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <Version>2.1.0</Version>
+    <Version>3.0.0</Version>
   </PropertyGroup>
 
   <ItemGroup>
@@ -21,8 +21,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-    <PackageReference Include="System.ComponentModel.Annotations" Version="4.7.0" />
+    <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
   </ItemGroup>
 
 </Project>
-

--- a/README.md
+++ b/README.md
@@ -87,3 +87,4 @@ NOTE: Be sure to merge the latest from "upstream" before making a pull request!
 | 1.0.0 | First version. |
 | 2.0.0 | Task renamed and refactored, it is not backward compatible. Updated documentation. |
 | 2.1.0 | Converted to support .Net Framework 4.7.1 and .Net Standard 2.0
+| 3.0.0 | Targeted to .NET6 and .NET8, and updated System.ComponentModel.Annotations to 5.0.0. |


### PR DESCRIPTION
Targeted to .NET6 and 8 and updated System.ComponentModel.Annotations. Removed symbols from the workflow since they were giving it trouble.